### PR TITLE
feat: add heroku-24 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Heroku Playwright Buildpack
 
 This buildpack installs all the needed dependencies to use Playwright with Chromium and Firefox on Heroku.
+It supports the heroku-18, heroku-20, heroku-22, and heroku-24 stacks.
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/mxschmitt/heroku-playwright-example)
 
@@ -56,7 +57,7 @@ const { firefox } = require("playwright-firefox");
 
 ## Best practises
 
-It's common to only install the [browser-specific NPM packages](https://playwright.dev/#version=v1.1.1&path=docs%2Finstallation.md&q=download-single-browser-binary), which will reduce installation time and slug size on Heroku in the end, that should fix also the error that the slug size is too large.
+It's common to only install the [browser-specific NPM packages](https://playwright.dev/docs/installation#download-single-browser-binary), which will reduce installation time and slug size on Heroku in the end, that should fix also the error that the slug size is too large.
 
 If you encounter this error at runtime, it means that you are missing the chromium binary, which can be installed with `playwright install chromium`.
 

--- a/bin/compile
+++ b/bin/compile
@@ -26,16 +26,21 @@ install_system_deps() {
 	local build_tmpdir=$(mktemp -d)
 	mkdir -p $build_tmpdir
 
-	SUPPORTED_BROWSERS=${PLAYWRIGHT_BUILDPACK_BROWSERS:-chromium,firefox,webkit}
-	echo "Installing Playwright dependencies (env: PLAYWRIGHT_BUILDPACK_BROWSERS) for $SUPPORTED_BROWSERS."
+        SUPPORTED_BROWSERS=${PLAYWRIGHT_BUILDPACK_BROWSERS:-chromium,firefox,webkit}
+        echo "Installing Playwright dependencies (env: PLAYWRIGHT_BUILDPACK_BROWSERS) for $SUPPORTED_BROWSERS."
 
-	if [[ "$SUPPORTED_BROWSERS" == *"chromium"* ]]; then
-		cat << EOF >>$build_tmpdir/Aptfile
+        local libasound_package="libasound2"
+        if [[ "$STACK" == "heroku-24" ]]; then
+                libasound_package="libasound2t64"
+        fi
+
+        if [[ "$SUPPORTED_BROWSERS" == *"chromium"* ]]; then
+                cat << EOF >>$build_tmpdir/Aptfile
 # Chromium dependencies
 libnspr4
 libnss3
 libxss1
-libasound2
+$libasound_package
 fonts-noto-color-emoji
 libgbm1
 libatk-bridge2.0-0
@@ -44,7 +49,7 @@ libxrandr2
 libatspi2.0-0
 libxshmfence-dev
 EOF
-	fi
+        fi
 
 	if [[ "$SUPPORTED_BROWSERS" == *"firefox"* ]]; then
 		cat << EOF >>$build_tmpdir/Aptfile
@@ -85,13 +90,18 @@ EOF
 libvpx6
 EOF
 	    ;;
-		"heroku-22")
-	    cat << EOF >>$build_tmpdir/Aptfile
+          "heroku-22")
+            cat << EOF >>$build_tmpdir/Aptfile
 libvpx7
 EOF
-	    ;;
-	  *)
-	    error "STACK must be 'heroku-18', 'heroku-20', or 'heroku-22'"
+            ;;
+          "heroku-24")
+            cat << EOF >>$build_tmpdir/Aptfile
+libvpx8
+EOF
+            ;;
+          *)
+            error "STACK must be 'heroku-18', 'heroku-20', 'heroku-22', or 'heroku-24'"
 	esac
 
 	local cache_tmpdir=$(mktemp -d)


### PR DESCRIPTION
## Summary
- add heroku-24 stack with libvpx8 dependency
- document support for heroku-24 and update Playwright docs link
- install libasound2t64 on heroku-24

## Testing
- `STACK=heroku-24 bash test/run.sh` *(fails: Unable to locate package libvpx8)*
- `STACK=heroku-22 bash test/run.sh` *(fails: Package 'libasound2' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68bea9395370832a8b6a87ac41effaae